### PR TITLE
import typing symbols directly rather than accessing the typing module

### DIFF
--- a/stubs/grpcio/@tests/test_cases/check_aio.py
+++ b/stubs/grpcio/@tests/test_cases/check_aio.py
@@ -1,21 +1,21 @@
 from __future__ import annotations
+from typing import Any, cast
 
-import typing
 from typing_extensions import assert_type
 
 import grpc.aio
 
 # Interceptor casts
-client_interceptors = [typing.cast(grpc.aio.ClientInterceptor, "interceptor")]
+client_interceptors: list[grpc.aio.ClientInterceptor] = []
 grpc.aio.insecure_channel("target", interceptors=client_interceptors)
 
-server_interceptors = [typing.cast(grpc.aio.ServerInterceptor[typing.Any, typing.Any], "interceptor")]
+server_interceptors: list[grpc.aio.ServerInterceptor[Any, Any]] = []
 grpc.aio.server(interceptors=server_interceptors)
 
 
 # Metadata
 async def metadata() -> None:
-    metadata = await typing.cast(grpc.aio.Call, None).initial_metadata()
+    metadata = await cast(grpc.aio.Call, None).initial_metadata()
     assert_type(metadata["foo"], grpc.aio._MetadataValue)
     for k in metadata:
         assert_type(k, str)

--- a/stubs/grpcio/@tests/test_cases/check_aio_multi_callable.py
+++ b/stubs/grpcio/@tests/test_cases/check_aio_multi_callable.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Any, Protocol, cast
+from typing import Protocol, cast
 
 from typing_extensions import assert_type
 

--- a/stubs/grpcio/@tests/test_cases/check_aio_multi_callable.py
+++ b/stubs/grpcio/@tests/test_cases/check_aio_multi_callable.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
+from typing import Any, Protocol, cast
 
-import typing
 from typing_extensions import assert_type
 
 import grpc.aio
@@ -14,14 +14,14 @@ class DummyReply:
     pass
 
 
-class DummyServiceStub(typing.Protocol):
+class DummyServiceStub(Protocol):
     UnaryUnary: grpc.aio.UnaryUnaryMultiCallable[DummyRequest, DummyReply]
     UnaryStream: grpc.aio.UnaryStreamMultiCallable[DummyRequest, DummyReply]
     StreamUnary: grpc.aio.StreamUnaryMultiCallable[DummyRequest, DummyReply]
     StreamStream: grpc.aio.StreamStreamMultiCallable[DummyRequest, DummyReply]
 
 
-stub: DummyServiceStub = typing.cast(typing.Any, None)
+stub = cast(DummyServiceStub, None)
 req = DummyRequest()
 
 

--- a/stubs/grpcio/@tests/test_cases/check_grpc.py
+++ b/stubs/grpcio/@tests/test_cases/check_grpc.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
+from typing import Optional, cast
 
-import typing
 from typing_extensions import assert_type
 
 import grpc
@@ -17,7 +17,7 @@ assert_type(creds, grpc.ChannelCredentials)
 # Other credential types:
 assert_type(grpc.alts_channel_credentials(), grpc.ChannelCredentials)
 assert_type(grpc.alts_server_credentials(), grpc.ServerCredentials)
-assert_type(grpc.compute_engine_channel_credentials(typing.cast(typing.Any, None)), grpc.ChannelCredentials)
+assert_type(grpc.compute_engine_channel_credentials(grpc.CallCredentials("")), grpc.ChannelCredentials)
 assert_type(grpc.insecure_server_credentials(), grpc.ServerCredentials)
 
 # XDS credentials:
@@ -38,9 +38,9 @@ assert_type(grpc.insecure_channel("target", [("a", "b"), ("c", "d")]), grpc.Chan
 # Client call details optionals:
 call_details = grpc.ClientCallDetails()
 assert_type(call_details.method, str)
-assert_type(call_details.timeout, typing.Optional[float])
+assert_type(call_details.timeout, Optional[float])
 
 # Call iterator
-call_iter: grpc._CallIterator[str] = typing.cast(typing.Any, None)
+call_iter = cast(grpc._CallIterator[str], None)
 for call in call_iter:
     assert_type(call, str)

--- a/stubs/grpcio/@tests/test_cases/check_handler_inheritance.py
+++ b/stubs/grpcio/@tests/test_cases/check_handler_inheritance.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
+from typing import cast
 
-import typing
 from typing_extensions import assert_type
 
 import grpc
@@ -30,7 +30,7 @@ class ServiceHandler(grpc.ServiceRpcHandler[Request, Response]):
 
 
 h = ServiceHandler()
-ctx = typing.cast(grpc.ServicerContext, None)
+ctx = cast(grpc.ServicerContext, None)
 svc = h.service(grpc.HandlerCallDetails())
 if svc is not None and svc.unary_unary is not None:
     svc.unary_unary(Request(), ctx)

--- a/stubs/grpcio/@tests/test_cases/check_multi_callable.py
+++ b/stubs/grpcio/@tests/test_cases/check_multi_callable.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
+from typing import Protocol, cast
 
-import typing
 from typing_extensions import assert_type
 
 import grpc
@@ -14,14 +14,14 @@ class DummyReply:
     pass
 
 
-class DummyServiceStub(typing.Protocol):
+class DummyServiceStub(Protocol):
     UnaryUnary: grpc.UnaryUnaryMultiCallable[DummyRequest, DummyReply]
     UnaryStream: grpc.UnaryStreamMultiCallable[DummyRequest, DummyReply]
     StreamUnary: grpc.StreamUnaryMultiCallable[DummyRequest, DummyReply]
     StreamStream: grpc.StreamStreamMultiCallable[DummyRequest, DummyReply]
 
 
-stub: DummyServiceStub = typing.cast(typing.Any, None)
+stub = cast(DummyServiceStub, None)
 req = DummyRequest()
 
 assert_type(stub.UnaryUnary(req), DummyReply)

--- a/stubs/grpcio/@tests/test_cases/check_reflection.py
+++ b/stubs/grpcio/@tests/test_cases/check_reflection.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
-
-import typing
+from typing import cast
 
 import grpc
 from grpc_reflection.v1alpha.reflection import enable_server_reflection
 
-server = typing.cast(grpc.Server, None)
+server = cast(grpc.Server, None)
 enable_server_reflection(["foo"], server, None)

--- a/stubs/grpcio/@tests/test_cases/check_reflection_aio.py
+++ b/stubs/grpcio/@tests/test_cases/check_reflection_aio.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
+from typing import cast
 
-import typing
 
 import grpc.aio
 from grpc_reflection.v1alpha.reflection import enable_server_reflection
 
-server = typing.cast(grpc.aio.Server, None)
+server = cast(grpc.aio.Server, None)
 enable_server_reflection(["foo"], server, None)

--- a/stubs/grpcio/@tests/test_cases/check_register.py
+++ b/stubs/grpcio/@tests/test_cases/check_register.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
-
-import typing
+from typing import Any
 
 import grpc
 
@@ -10,5 +9,5 @@ class CallProxy:
     def __init__(self, target: grpc.Call) -> None:
         self._target = target
 
-    def __getattr__(self, name: str) -> typing.Any:
+    def __getattr__(self, name: str) -> Any:
         return getattr(self._target, name)

--- a/stubs/grpcio/@tests/test_cases/check_server_interceptor.py
+++ b/stubs/grpcio/@tests/test_cases/check_server_interceptor.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
-
-import typing
-
+from collections.abc import Callable
 import grpc
 
 
@@ -16,7 +14,7 @@ class Response:
 class NoopInterceptor(grpc.ServerInterceptor[Request, Response]):
     def intercept_service(
         self,
-        continuation: typing.Callable[[grpc.HandlerCallDetails], grpc.RpcMethodHandler[Request, Response] | None],
+        continuation: Callable[[grpc.HandlerCallDetails], grpc.RpcMethodHandler[Request, Response] | None],
         handler_call_details: grpc.HandlerCallDetails,
     ) -> grpc.RpcMethodHandler[Request, Response] | None:
         return continuation(handler_call_details)

--- a/stubs/grpcio/grpc/__init__.pyi
+++ b/stubs/grpcio/grpc/__init__.pyi
@@ -1,10 +1,10 @@
 import abc
 import enum
 import threading
-import typing
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from concurrent import futures
 from types import ModuleType, TracebackType
+from typing import Any, Generic, NoReturn, Protocol, TypeVar, type_check_only
 from typing_extensions import Self, TypeAlias
 
 __version__: str
@@ -12,16 +12,16 @@ __version__: str
 # This class encodes an uninhabited type, requiring use of explicit casts or ignores
 # in order to satisfy type checkers. This allows grpc-stubs to add proper stubs
 # later, allowing those overrides to be removed.
-# The alternative is typing.Any, but a future replacement of Any with a proper type
+# The alternative is Any, but a future replacement of Any with a proper type
 # would result in type errors where previously the type checker was happy, which
 # we want to avoid. Forcing the user to use overrides provides forwards-compatibility.
-@typing.type_check_only
+@type_check_only
 class _PartialStubMustCastOrIgnore: ...
 
 # XXX: Early attempts to tame this used literals for all the keys (gRPC is
 # a bit segfaulty and doesn't adequately validate the option keys), but that
 # didn't quite work out. Maybe it's something we can come back to?
-_OptionKeyValue: TypeAlias = tuple[str, typing.Any]
+_OptionKeyValue: TypeAlias = tuple[str, Any]
 _Options: TypeAlias = Sequence[_OptionKeyValue]
 
 class Compression(enum.IntEnum):
@@ -41,35 +41,35 @@ class LocalConnectionType(enum.Enum):
 # - https://github.com/grpc/grpc/blob/0e1984effd7e977ef18f1ad7fde7d10a2a153e1d/src/python/grpcio_tests/tests/unit/_invocation_defects_test.py#L66
 _Metadata: TypeAlias = tuple[tuple[str, str | bytes], ...]
 
-_TRequest = typing.TypeVar("_TRequest")
-_TResponse = typing.TypeVar("_TResponse")
+_TRequest = TypeVar("_TRequest")
+_TResponse = TypeVar("_TResponse")
 
 # XXX: These are probably the SerializeToTring/FromString pb2 methods, but
 # this needs further investigation
-@typing.type_check_only
-class _RequestSerializer(typing.Protocol):
-    def __call__(self, *args: typing.Any, **kwargs: typing.Any) -> typing.Any: ...
+@type_check_only
+class _RequestSerializer(Protocol):
+    def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
 
-@typing.type_check_only
-class _RequestDeserializer(typing.Protocol):
-    def __call__(self, *args: typing.Any, **kwargs: typing.Any) -> typing.Any: ...
+@type_check_only
+class _RequestDeserializer(Protocol):
+    def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
 
-@typing.type_check_only
-class _ResponseSerializer(typing.Protocol):
-    def __call__(self, *args: typing.Any, **kwargs: typing.Any) -> typing.Any: ...
+@type_check_only
+class _ResponseSerializer(Protocol):
+    def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
 
-@typing.type_check_only
-class _ResponseDeserializer(typing.Protocol):
-    def __call__(self, *args: typing.Any, **kwargs: typing.Any) -> typing.Any: ...
+@type_check_only
+class _ResponseDeserializer(Protocol):
+    def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
 
 # Future Interfaces:
 
 class FutureTimeoutError(Exception): ...
 class FutureCancelledError(Exception): ...
 
-_TFutureValue = typing.TypeVar("_TFutureValue")
+_TFutureValue = TypeVar("_TFutureValue")
 
-class Future(abc.ABC, typing.Generic[_TFutureValue]):
+class Future(abc.ABC, Generic[_TFutureValue]):
     @abc.abstractmethod
     def add_done_callback(self, fn: Callable[[Future[_TFutureValue]], None]) -> None: ...
     @abc.abstractmethod
@@ -87,7 +87,7 @@ class Future(abc.ABC, typing.Generic[_TFutureValue]):
 
     # FIXME: unsure of the exact return type here. Is it a traceback.StackSummary?
     @abc.abstractmethod
-    def traceback(self, timeout: float | None = ...) -> typing.Any: ...
+    def traceback(self, timeout: float | None = ...) -> Any: ...
 
 # Create Client:
 
@@ -129,8 +129,8 @@ def composite_channel_credentials(
 
 def server(
     thread_pool: futures.ThreadPoolExecutor,
-    handlers: list[GenericRpcHandler[typing.Any, typing.Any]] | None = ...,
-    interceptors: list[ServerInterceptor[typing.Any, typing.Any]] | None = ...,
+    handlers: list[GenericRpcHandler[Any, Any]] | None = ...,
+    interceptors: list[ServerInterceptor[Any, Any]] | None = ...,
     options: _Options | None = ...,
     maximum_concurrent_rpcs: int | None = ...,
     compression: Compression | None = ...,
@@ -168,33 +168,33 @@ def xds_server_credentials(fallback_credentials: ServerCredentials) -> ServerCre
 #    def FloobDoob(self, request, context):
 #       return response
 #
-@typing.type_check_only
-class _Behaviour(typing.Protocol):
-    def __call__(self, *args: typing.Any, **kwargs: typing.Any) -> typing.Any: ...
+@type_check_only
+class _Behaviour(Protocol):
+    def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
 
 def unary_unary_rpc_method_handler(
     behavior: _Behaviour,
     request_deserializer: _RequestDeserializer | None = ...,
     response_serializer: _ResponseSerializer | None = ...,
-) -> RpcMethodHandler[typing.Any, typing.Any]: ...
+) -> RpcMethodHandler[Any, Any]: ...
 def unary_stream_rpc_method_handler(
     behavior: _Behaviour,
     request_deserializer: _RequestDeserializer | None = ...,
     response_serializer: _ResponseSerializer | None = ...,
-) -> RpcMethodHandler[typing.Any, typing.Any]: ...
+) -> RpcMethodHandler[Any, Any]: ...
 def stream_unary_rpc_method_handler(
     behavior: _Behaviour,
     request_deserializer: _RequestDeserializer | None = ...,
     response_serializer: _ResponseSerializer | None = ...,
-) -> RpcMethodHandler[typing.Any, typing.Any]: ...
+) -> RpcMethodHandler[Any, Any]: ...
 def stream_stream_rpc_method_handler(
     behavior: _Behaviour,
     request_deserializer: _RequestDeserializer | None = ...,
     response_serializer: _ResponseSerializer | None = ...,
-) -> RpcMethodHandler[typing.Any, typing.Any]: ...
+) -> RpcMethodHandler[Any, Any]: ...
 def method_handlers_generic_handler(
-    service: str, method_handlers: dict[str, RpcMethodHandler[typing.Any, typing.Any]]
-) -> GenericRpcHandler[typing.Any, typing.Any]: ...
+    service: str, method_handlers: dict[str, RpcMethodHandler[Any, Any]]
+) -> GenericRpcHandler[Any, Any]: ...
 
 # Channel Ready Future:
 
@@ -250,14 +250,14 @@ class Channel(abc.ABC):
         method: str,
         request_serializer: _RequestSerializer | None = ...,
         response_deserializer: _ResponseDeserializer | None = ...,
-    ) -> StreamStreamMultiCallable[typing.Any, typing.Any]: ...
+    ) -> StreamStreamMultiCallable[Any, Any]: ...
     @abc.abstractmethod
     def stream_unary(
         self,
         method: str,
         request_serializer: _RequestSerializer | None = ...,
         response_deserializer: _ResponseDeserializer | None = ...,
-    ) -> StreamUnaryMultiCallable[typing.Any, typing.Any]: ...
+    ) -> StreamUnaryMultiCallable[Any, Any]: ...
     @abc.abstractmethod
     def subscribe(self, callback: Callable[[ChannelConnectivity], None], try_to_connect: bool = ...) -> None: ...
     @abc.abstractmethod
@@ -266,14 +266,14 @@ class Channel(abc.ABC):
         method: str,
         request_serializer: _RequestSerializer | None = ...,
         response_deserializer: _ResponseDeserializer | None = ...,
-    ) -> UnaryStreamMultiCallable[typing.Any, typing.Any]: ...
+    ) -> UnaryStreamMultiCallable[Any, Any]: ...
     @abc.abstractmethod
     def unary_unary(
         self,
         method: str,
         request_serializer: _RequestSerializer | None = ...,
         response_deserializer: _ResponseDeserializer | None = ...,
-    ) -> UnaryUnaryMultiCallable[typing.Any, typing.Any]: ...
+    ) -> UnaryUnaryMultiCallable[Any, Any]: ...
     @abc.abstractmethod
     def unsubscribe(self, callback: Callable[[ChannelConnectivity], None]) -> None: ...
     def __enter__(self) -> Self: ...
@@ -285,7 +285,7 @@ class Channel(abc.ABC):
 
 class Server(abc.ABC):
     @abc.abstractmethod
-    def add_generic_rpc_handlers(self, generic_rpc_handlers: Iterable[GenericRpcHandler[typing.Any, typing.Any]]) -> None: ...
+    def add_generic_rpc_handlers(self, generic_rpc_handlers: Iterable[GenericRpcHandler[Any, Any]]) -> None: ...
 
     # Returns an integer port on which server will accept RPC requests.
     @abc.abstractmethod
@@ -335,7 +335,7 @@ class ServerCertificateConfiguration:
 
 # gRPC Exceptions:
 
-@typing.type_check_only
+@type_check_only
 class _Metadatum:
     key: str
     value: bytes
@@ -396,10 +396,10 @@ class ClientCallDetails(abc.ABC):
 # response message of the RPC. Should the event terminate with non-OK
 # status, the returned Call-Future's exception value will be an RpcError.
 #
-@typing.type_check_only
+@type_check_only
 class _CallFuture(Call, Future[_TResponse], metaclass=abc.ABCMeta): ...
 
-class UnaryUnaryClientInterceptor(abc.ABC, typing.Generic[_TRequest, _TResponse]):
+class UnaryUnaryClientInterceptor(abc.ABC, Generic[_TRequest, _TResponse]):
     @abc.abstractmethod
     def intercept_unary_unary(
         self,
@@ -423,11 +423,11 @@ class UnaryUnaryClientInterceptor(abc.ABC, typing.Generic[_TRequest, _TResponse]
         request: _TRequest,
     ) -> _CallFuture[_TResponse]: ...
 
-@typing.type_check_only
-class _CallIterator(Call, typing.Generic[_TResponse], metaclass=abc.ABCMeta):
+@type_check_only
+class _CallIterator(Call, Generic[_TResponse], metaclass=abc.ABCMeta):
     def __iter__(self) -> Iterator[_TResponse]: ...
 
-class UnaryStreamClientInterceptor(abc.ABC, typing.Generic[_TRequest, _TResponse]):
+class UnaryStreamClientInterceptor(abc.ABC, Generic[_TRequest, _TResponse]):
     @abc.abstractmethod
     def intercept_unary_stream(
         self,
@@ -436,7 +436,7 @@ class UnaryStreamClientInterceptor(abc.ABC, typing.Generic[_TRequest, _TResponse
         request: _TRequest,
     ) -> _CallIterator[_TResponse]: ...
 
-class StreamUnaryClientInterceptor(abc.ABC, typing.Generic[_TRequest, _TResponse]):
+class StreamUnaryClientInterceptor(abc.ABC, Generic[_TRequest, _TResponse]):
     @abc.abstractmethod
     def intercept_stream_unary(
         self,
@@ -445,7 +445,7 @@ class StreamUnaryClientInterceptor(abc.ABC, typing.Generic[_TRequest, _TResponse
         request_iterator: Iterator[_TRequest],
     ) -> _CallFuture[_TResponse]: ...
 
-class StreamStreamClientInterceptor(abc.ABC, typing.Generic[_TRequest, _TResponse]):
+class StreamStreamClientInterceptor(abc.ABC, Generic[_TRequest, _TResponse]):
     @abc.abstractmethod
     def intercept_stream_stream(
         self,
@@ -459,9 +459,9 @@ class StreamStreamClientInterceptor(abc.ABC, typing.Generic[_TRequest, _TRespons
 class ServicerContext(RpcContext, metaclass=abc.ABCMeta):
     # misnamed parameter 'details', does not align with status.proto, where it is called 'message':
     @abc.abstractmethod
-    def abort(self, code: StatusCode, details: str) -> typing.NoReturn: ...
+    def abort(self, code: StatusCode, details: str) -> NoReturn: ...
     @abc.abstractmethod
-    def abort_with_status(self, status: Status) -> typing.NoReturn: ...
+    def abort_with_status(self, status: Status) -> NoReturn: ...
 
     # FIXME: The docs say "A map of strings to an iterable of bytes for each auth property".
     # Does that mean 'bytes' (which is iterable), or 'Iterable[bytes]'?
@@ -491,7 +491,7 @@ class ServicerContext(RpcContext, metaclass=abc.ABCMeta):
 
 # Service-Side Handler:
 
-class RpcMethodHandler(abc.ABC, typing.Generic[_TRequest, _TResponse]):
+class RpcMethodHandler(abc.ABC, Generic[_TRequest, _TResponse]):
     request_streaming: bool
     response_streaming: bool
 
@@ -513,7 +513,7 @@ class HandlerCallDetails(abc.ABC):
     method: str
     invocation_metadata: _Metadata
 
-class GenericRpcHandler(abc.ABC, typing.Generic[_TRequest, _TResponse]):
+class GenericRpcHandler(abc.ABC, Generic[_TRequest, _TResponse]):
     @abc.abstractmethod
     def service(self, handler_call_details: HandlerCallDetails) -> RpcMethodHandler[_TRequest, _TResponse] | None: ...
 
@@ -523,7 +523,7 @@ class ServiceRpcHandler(GenericRpcHandler[_TRequest, _TResponse], metaclass=abc.
 
 # Service-Side Interceptor:
 
-class ServerInterceptor(abc.ABC, typing.Generic[_TRequest, _TResponse]):
+class ServerInterceptor(abc.ABC, Generic[_TRequest, _TResponse]):
     @abc.abstractmethod
     def intercept_service(
         self,
@@ -533,7 +533,7 @@ class ServerInterceptor(abc.ABC, typing.Generic[_TRequest, _TResponse]):
 
 # Multi-Callable Interfaces:
 
-class UnaryUnaryMultiCallable(abc.ABC, typing.Generic[_TRequest, _TResponse]):
+class UnaryUnaryMultiCallable(abc.ABC, Generic[_TRequest, _TResponse]):
     @abc.abstractmethod
     def __call__(
         self,
@@ -570,7 +570,7 @@ class UnaryUnaryMultiCallable(abc.ABC, typing.Generic[_TRequest, _TResponse]):
         # this is slightly unclear so this return type is a best-effort guess.
     ) -> tuple[_TResponse, Call]: ...
 
-class UnaryStreamMultiCallable(abc.ABC, typing.Generic[_TRequest, _TResponse]):
+class UnaryStreamMultiCallable(abc.ABC, Generic[_TRequest, _TResponse]):
     @abc.abstractmethod
     def __call__(
         self,
@@ -583,7 +583,7 @@ class UnaryStreamMultiCallable(abc.ABC, typing.Generic[_TRequest, _TResponse]):
         compression: Compression | None = ...,
     ) -> _CallIterator[_TResponse]: ...
 
-class StreamUnaryMultiCallable(abc.ABC, typing.Generic[_TRequest, _TResponse]):
+class StreamUnaryMultiCallable(abc.ABC, Generic[_TRequest, _TResponse]):
     @abc.abstractmethod
     def __call__(
         self,
@@ -620,7 +620,7 @@ class StreamUnaryMultiCallable(abc.ABC, typing.Generic[_TRequest, _TResponse]):
         # this is slightly unclear so this return type is a best-effort guess.
     ) -> tuple[_TResponse, Call]: ...
 
-class StreamStreamMultiCallable(abc.ABC, typing.Generic[_TRequest, _TResponse]):
+class StreamStreamMultiCallable(abc.ABC, Generic[_TRequest, _TResponse]):
     @abc.abstractmethod
     def __call__(
         self,

--- a/stubs/grpcio/grpc_health/v1/health.pyi
+++ b/stubs/grpcio/grpc_health/v1/health.pyi
@@ -1,5 +1,5 @@
-import typing
 from concurrent import futures
+from typing import Any, Protocol
 
 from grpc import ServicerContext
 from grpc_health.v1 import health_pb2 as _health_pb2, health_pb2_grpc as _health_pb2_grpc
@@ -16,8 +16,8 @@ class _Watcher:
     def close(self) -> None: ...
 
 # FIXME: This needs further investigation
-class _SendResponseCallback(typing.Protocol):
-    def __call__(self, *args: typing.Any, **kwargs: typing.Any) -> typing.Any: ...
+class _SendResponseCallback(Protocol):
+    def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
 
 class HealthServicer(_health_pb2_grpc.HealthServicer):
     def __init__(

--- a/stubs/grpcio/grpc_status/rpc_status.pyi
+++ b/stubs/grpcio/grpc_status/rpc_status.pyi
@@ -1,4 +1,4 @@
-import typing
+from typing import Any
 
 import grpc
 
@@ -7,7 +7,7 @@ import grpc
 # google.rpc as well.
 
 # Returns a google.rpc.status.Status message corresponding to a given grpc.Call.
-def from_call(call: grpc.Call) -> typing.Any: ...
+def from_call(call: grpc.Call) -> Any: ...
 
 # Convert a google.rpc.status.Status message to grpc.Status.
-def to_status(status: typing.Any) -> grpc.Status: ...
+def to_status(status: Any) -> grpc.Status: ...


### PR DESCRIPTION
Addresses review comment https://github.com/python/typeshed/pull/11204#discussion_r2022774951 by @Srittau
I also simplified some `cast` along the way.